### PR TITLE
Changed JHU CSSE sitrep time series URL (Confirmed and Deaths)

### DIFF
--- a/R/sitrep_jhu.R
+++ b/R/sitrep_jhu.R
@@ -48,7 +48,7 @@
 #'
 jhu_sitrep_import <- function(source) {
   if (source=="confirmed") {
-    path_start <- "https://raw.github.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Confirmed.csv"
+    path_start <- "https://raw.github.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv"
     jhu_sitrep <- read_csv(file = path_start) %>%
       mutate(source=source) %>%
       select(source,everything())
@@ -62,7 +62,7 @@ jhu_sitrep_import <- function(source) {
   }
 
   if (source=="recovered") {
-    path_start <- "https://raw.github.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Recovered.csv"
+    path_start <- "https://raw.github.com/CSSEGISandData/COVID-19/master/csse_covid_19_data//time_series_covid19_deaths_global.csv"
     jhu_sitrep <- read_csv(file = path_start) %>%
       mutate(source=source) %>%
       select(source,everything())


### PR DESCRIPTION
Hola Andree,

Me di cuenta que el repo fuente de JHU CSSE ha notificado que no actualizará más los csv que estabas referenciando en *jhu_sitrep_import*.

He actualizado a los urls que se utilizaran a partir de ahora:

* time_series_covid19_confirmed_global.csv
* time_series_covid19_deaths_global.csv

Respecto al URL de **Recovered** tal vez deberías ponerle un *warning()* que ya no se actualizará. Ya lo probé y está todo ok. 

Saludos